### PR TITLE
Read SSL keystore and truststore from resolved path

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/ControllerNetComInitializer.java
+++ b/controller/src/main/java/com/linbit/linstor/core/ControllerNetComInitializer.java
@@ -398,10 +398,10 @@ public final class ControllerNetComInitializer
                         initCtx,
                         ctrlConnTracker,
                         sslProtocol,
-                        keyStoreFile,
+                        keyStoreFilePath.toString(),
                         keyStorePw.toCharArray(),
                         keyPw.toCharArray(),
-                        trustStoreFile,
+                        trustStoreFilePath.toString(),
                         trustStorPw.toCharArray()
                     );
                     try


### PR DESCRIPTION
The SSL network communication service reads keystore based on relative path and fails with the error:
`ERROR LINSTOR/Controller - Initialization of an SSL-enabled network communication service failed`
`ERROR LINSTOR/Controller - ssl/keystore.jks (No such file or directory)`

The `keyStoreFilePath` and `trustStoreFilePath` are checked for existence in the previous block (lines 364-387) and point to absolute paths of the keystore and truststore. This fix should resolve the above error.