### PR TITLE
Enable mutual SSL authentication for controller and satellite

### DIFF
--- a/server/src/main/java/com/linbit/linstor/netcom/ssl/SslTcpConnectorPeer.java
+++ b/server/src/main/java/com/linbit/linstor/netcom/ssl/SslTcpConnectorPeer.java
@@ -62,7 +62,7 @@ public class SslTcpConnectorPeer extends TcpConnectorPeer
         {
             // Server mode
             sslEngine = sslCtx.createSSLEngine();
-            sslEngine.setNeedClientAuth(false);
+            sslEngine.setNeedClientAuth(true);
             sslEngine.setUseClientMode(false);
         }
 
@@ -120,7 +120,7 @@ public class SslTcpConnectorPeer extends TcpConnectorPeer
         {
             // Server mode
             sslEngine = sslCtx.createSSLEngine();
-            sslEngine.setNeedClientAuth(false);
+            sslEngine.setNeedClientAuth(true);
             sslEngine.setUseClientMode(false);
         }
 


### PR DESCRIPTION
As discussed in issue #20 this enables the usage of mutual SSL authentication to verify the client certificate and key sent from keystore are present in the truststore of the controller or satellite.

I have tested this works with both controller-satellite and client-controller connections. However I had to use the version 3 of the API and fork the linstor-client to send client keys when wrapping the SSL socket. As the version 4 of the API currently only supports HTTP it would great if the controller could also bind a HTTPS port to support 2-way SSL authentication.