### PR TITLE
Add truststore to config and HTTPS rest-api for SSL auth

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/Controller.java
+++ b/controller/src/main/java/com/linbit/linstor/core/Controller.java
@@ -300,6 +300,8 @@ public final class Controller
         String restBindAddresSecure;
         Path keyStorePath = null;
         String keyStorePassword;
+        Path trustStorePath = null;
+        String trustStorePassword;
         try
         {
             if (cArgs.getRESTBindAddress() != null)
@@ -345,6 +347,7 @@ public final class Controller
             }
 
             final String keyStorePathProp = linstorConfig.getHTTPS().getKeystore();
+            final String trustStorePathProp = linstorConfig.getHTTPS().getTruststore();
             if (keyStorePathProp != null)
             {
                 keyStorePath = Paths.get(keyStorePathProp);
@@ -353,8 +356,17 @@ public final class Controller
                     keyStorePath = cArgs.getConfigurationDirectory().resolve(keyStorePath);
                 }
             }
+            if (trustStorePathProp != null)
+            {
+                trustStorePath = Paths.get(trustStorePathProp);
+                if (!trustStorePath.isAbsolute())
+                {
+                    trustStorePath = cArgs.getConfigurationDirectory().resolve(trustStorePath);
+                }
+            }
 
             keyStorePassword = linstorConfig.getHTTPS().getKeystorePassword();
+            trustStorePassword = linstorConfig.getHTTPS().getTruststorePassword();
 
             if (restEnabled)
             {
@@ -365,7 +377,9 @@ public final class Controller
                     restBindAddress,
                     restBindAddresSecure,
                     keyStorePath,
-                    keyStorePassword
+                    keyStorePassword,
+                    trustStorePath,
+                    trustStorePassword
                 );
                 systemServicesMap.put(grizzlyHttpService.getInstanceName(), grizzlyHttpService);
             }

--- a/controller/src/main/java/com/linbit/linstor/core/LinstorConfigToml.java
+++ b/controller/src/main/java/com/linbit/linstor/core/LinstorConfigToml.java
@@ -31,6 +31,8 @@ public class LinstorConfigToml
         private int port = Controller.DEFAULT_HTTPS_REST_PORT;
         private String keystore;
         private String keystore_password = "";
+        private String truststore;
+        private String truststore_password = "";
 
         public boolean isEnabled()
         {
@@ -55,6 +57,16 @@ public class LinstorConfigToml
         public String getKeystorePassword()
         {
             return keystore_password;
+        }
+
+        public String getTruststore()
+        {
+            return truststore;
+        }
+
+        public String getTruststorePassword()
+        {
+            return truststore_password;
         }
     }
 


### PR DESCRIPTION
This PR adds a truststore option to the TOML configuration which is read when setting up the HTTPS rest-api. When a truststore is provided in the config the HTTPS rest-api will enforce mutual SSL authentication by setting the `SSLEngineConfigurator.setNeedClientAuth` option to `true`.

I'm also creating two related PRs in linstor-client and linstor-api-py to enable SSL authentication from the client side.