### PR TITLE
Add Sentry integration to capture error info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
 //            compile group: 'com.google.protobuf', name: 'protobuf-javalite', version: protobufVersion
             compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
 
+            compile 'io.sentry:sentry:1.7.30'
             compile 'info.picocli:picocli:3.9.5'
             compile group: 'io.projectreactor', name: 'reactor-core', version: '3.2.9.RELEASE'
             compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'

--- a/controller/src/main/java/com/linbit/linstor/core/Controller.java
+++ b/controller/src/main/java/com/linbit/linstor/core/Controller.java
@@ -71,6 +71,7 @@ import com.linbit.linstor.transaction.ControllerTransactionMgrModule;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -393,6 +394,9 @@ public final class Controller
 
         System.setProperty("log.module", LinStor.CONTROLLER_MODULE);
         System.setProperty("log.directory", cfg.getLogDirectory());
+
+        Path sentryFilePath = Paths.get(cfg.getConfigDir(), "sentry.properties");
+        System.setProperty("sentry.properties.file", sentryFilePath.toString());
 
         System.out.printf("%s, Module %s\n", LinStor.PROGRAM, LinStor.CONTROLLER_MODULE);
         LinStor.printStartupInfo();

--- a/satellite/src/main/java/com/linbit/linstor/core/Satellite.java
+++ b/satellite/src/main/java/com/linbit/linstor/core/Satellite.java
@@ -391,6 +391,9 @@ public final class Satellite
         System.setProperty("log.module", LinStor.SATELLITE_MODULE);
         System.setProperty("log.directory", cfg.getLogDirectory());
 
+        Path sentryFilePath = Paths.get(cfg.getConfigDir(), "sentry.properties");
+        System.setProperty("sentry.properties.file", sentryFilePath.toString());
+
         System.out.printf("%s, Module %s\n", LinStor.PROGRAM, LinStor.SATELLITE_MODULE);
         LinStor.printStartupInfo();
 

--- a/server/src/main/java/com/linbit/linstor/logging/StdErrorReporter.java
+++ b/server/src/main/java/com/linbit/linstor/logging/StdErrorReporter.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
@@ -103,6 +104,12 @@ public final class StdErrorReporter extends BaseErrorReporter implements ErrorRe
         }
 
         logInfo("Log directory set to: '" + logDir + "'");
+
+        System.setProperty("sentry.release", LinStor.VERSION_INFO_PROVIDER.getVersion());
+        System.setProperty("sentry.servername", nodeName);
+        System.setProperty("sentry.tags", "module:" + moduleName);
+        System.setProperty("sentry.stacktrace.app.packages", "com.linbit");
+        Sentry.init();
     }
 
     @Override
@@ -351,6 +358,8 @@ public final class StdErrorReporter extends BaseErrorReporter implements ErrorRe
                     );
                     break;
             }
+
+            Sentry.capture(errorInfo);
         }
         finally
         {
@@ -499,6 +508,8 @@ public final class StdErrorReporter extends BaseErrorReporter implements ErrorRe
                 }
 
                 output.println("\nEND OF ERROR REPORT.\n");
+
+                Sentry.capture(errorInfo);
             }
         }
         finally


### PR DESCRIPTION
This PR adds a Sentry integration for capturing error inline in addition to writing out to error reports. Without any external configuration the Sentry capture will be a no-op. To configure the Sentry client you may set options in the `sentry.properties` file see https://docs.sentry.io/clients/java/config/. By default this should be located in the Linstor configuration directory.

I prefer centralised error tracking to log files only as I can better react and monitor when production issues occur.