### PR TITLE
subdomain update for download URLs from www to pkg

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -19,7 +19,7 @@ RUN rpm -e --nodeps fakesystemd && yum install -y systemd && yum clean all -y ||
 
 RUN mkdir -p /tmp/linstor-$LINSTOR_VERSION
 # one can not comment COPY
-RUN cd /tmp && wget https://www.linbit.com/downloads/linstor/$LINSTOR_TGZ # !lbbuild
+RUN cd /tmp && wget https://pkg.linbit.com/downloads/linstor/$LINSTOR_TGZ # !lbbuild
 # =lbbuild COPY /${LINSTOR_TGZ} /tmp/
 
 # =lbbuild COPY /pkgcache/* /tmp/pkgcache/

--- a/Dockerfile.satellite
+++ b/Dockerfile.satellite
@@ -38,7 +38,7 @@ RUN rpm -e --nodeps fakesystemd && yum install -y systemd && yum clean all -y ||
 
 RUN mkdir -p /tmp/linstor-$LINSTOR_VERSION
 # one can not comment COPY
-RUN cd /tmp && wget https://www.linbit.com/downloads/linstor/$LINSTOR_TGZ # !lbbuild
+RUN cd /tmp && wget https://pkg.linbit.com/downloads/linstor/$LINSTOR_TGZ # !lbbuild
 # =lbbuild COPY /${LINSTOR_TGZ} /tmp/
 
 # =lbbuild COPY /pkgcache/* /tmp/pkgcache/

--- a/linstor.spec
+++ b/linstor.spec
@@ -16,7 +16,7 @@ BuildArch: noarch
 Group: System Environment/Daemons
 License: GPLv2+
 URL: https://github.com/LINBIT/linstor-server
-Source0: http://www.linbit.com/downloads/linstor/linstor-server-%{FILE_VERSION}.tar.gz
+Source0: http://pkg.linbit.com/downloads/linstor/linstor-server-%{FILE_VERSION}.tar.gz
 
 %if 0%{?suse_version} >= 1500
 BuildRequires: java-1_8_0-openjdk-headless java-1_8_0-openjdk-devel python

--- a/virter/provision-centos.toml
+++ b/virter/provision-centos.toml
@@ -9,14 +9,14 @@ sed -i 's/# global_filter = \[/global_filter = \[ "r|\/dev\/drbd\.\*|", /g' /etc
 KERNEL=$(rpm -qa kernel | tail -n1 | cut -c8-)
 
 cd /tmp
-curl -O https://www.linbit.com/downloads/drbd/9.0/drbd-9.0.23-0rc1.tar.gz
+curl -O https://pkg.linbit.com/downloads/drbd/9.0/drbd-9.0.23-0rc1.tar.gz
 tar xzf drbd-9.0.23-0rc1.tar.gz
 cd /tmp/drbd-9.0.23-0rc1
 make -j2 KDIR=/usr/src/kernels/$KERNEL
 make install
 
 cd /tmp
-curl -O https://www.linbit.com/downloads/drbd/utils/drbd-utils-9.13.1.tar.gz
+curl -O https://pkg.linbit.com/downloads/drbd/utils/drbd-utils-9.13.1.tar.gz
 tar xzf drbd-utils-9.13.1.tar.gz
 cd /tmp/drbd-utils-9.13.1
 ./configure --prefix= --without-manual


### PR DESCRIPTION
The subdomain for LINBIT's source tarballs recently changed from
www.linbit.com to pkg.linbit.com. This commit updates the subdomain for
all downloads.