### PR TITLE
Fix s3 multipart upload bug involving unit mismatch

### DIFF
--- a/server/src/main/java/com/linbit/linstor/api/BackupToS3.java
+++ b/server/src/main/java/com/linbit/linstor/api/BackupToS3.java
@@ -117,7 +117,7 @@ public class BackupToS3
 
         // make the buffer size (part size) as big as possible, without going over the limit of Integer.MAX_VALUE
         // while making sure to stay above the minimum part size of 5 MB and below 10000 parts
-        long bufferSize = Math.max(5 << 20, (long) (Math.ceil(maxSize / 10000.0) + 1.0));
+        long bufferSize = Math.max(5 << 20, (long) (Math.ceil((maxSize * 1024) / 10000.0) + 1.0));
         if (bufferSize > Integer.MAX_VALUE)
         {
             throw new StorageException(


### PR DESCRIPTION
In BackupToS3.java, the calculation for `bufferSize` previously assumed that `maxSize` was passed in with the number of bytes as the unit, but it is the number of kilobytes. This PR just multiplies the value of `maxSize` by 1024 to make the units equivalent. This bug manifests itself when trying to upload backups to s3 remotes that are larger than 50GB. 

I'm not completely familiar with the commit style/code style of this project, so if there are any corrections that I need to make, please let me know and I'll get everything fixed up.