### PR TITLE
Respect snap_name parameter for in-progress backups

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/backup/CtrlBackupApiCallHandler.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/backup/CtrlBackupApiCallHandler.java
@@ -751,6 +751,12 @@ public class CtrlBackupApiCallHandler
                 String rscName = rscDfn.getName().displayValue;
                 String snapName = snapDfn.getName().displayValue;
 
+                if (snapNameRef != null && !snapNameRef.isEmpty() && snapNameRef.equals(snapName))
+                {
+                    // Doesn't match the requested snapshot name, skip it.
+                    continue;
+                }
+
                 String s3Suffix = snapDfn.getProps(peerCtx).getProp(
                     ApiConsts.KEY_BACKUP_S3_SUFFIX,
                     ApiConsts.NAMESPC_BACKUP_SHIPPING


### PR DESCRIPTION
Before this change, if any backups were in-progress other snapshot operations driven by the CSI would break. Concretely, the bug is:
```
$ curl -H 'Accept: application/json' 'http://piraeus-op-cs.piraeus.svc:3370/v1/remotes/minio/backups?snap_name=INVALID_NAME'
{"linstor":{"pvc-621a06d8-0503-4cf3-84af-d75e1bf40508_back_20220915_234444^snapshot-351f10f6-5b7a-4527-bdd3-0bb7a01bc18a":{"id":"pvc-621a06d8-0503-4cf3-84af-d75e1bf40508_back_20220915_234444^snapshot-351f10f6-5b7a-4527-bdd3-0bb7a01bc18a","start_time":"20220915_234444","start_timestamp":1663285484376,"origin_rsc":"pvc-621a06d8-0503-4cf3-84af-d75e1bf40508","origin_snap":"snapshot-351f10f6-5b7a-4527-bdd3-0bb7a01bc18a","origin_node":"pi4a","vlms":[{"vlm_nr":0,"s3":{"key":"pvc-621a06d8-0503-4cf3-84af-d75e1bf40508_00000_back_20220915_234444^snapshot-351f10f6-5b7a-4527-bdd3-0bb7a01bc18a"}}],"shipping":true,"restorable":false}},"other":{}}
```

Refs https://github.com/piraeusdatastore/linstor-csi/issues/174