### PR TITLE
Fix size-check for meta-pools with resize volume case

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlVlmDfnModifyApiCallHandler.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlVlmDfnModifyApiCallHandler.java
@@ -644,7 +644,12 @@ public class CtrlVlmDfnModifyApiCallHandler implements CtrlSatelliteConnectionLi
             while (rscIt.hasNext())
             {
                 Resource rsc = rscIt.next();
-                Set<StorPool> storPools = LayerVlmUtils.getStorPools(rsc, apiCtx, true);
+                /*
+                 * TODO: improve this size check of metadata.
+                 *  Metadata size check skipped by workaround "withMetaStoragePools=false".
+                 *  This might fail later if a meta-pool runs out of space on the satellite.
+                 */
+                Set<StorPool> storPools = LayerVlmUtils.getStorPools(rsc, apiCtx, false);
                 for (StorPool sp : storPools)
                 {
                     if (!sp.getDeviceProviderKind().usesThinProvisioning())


### PR DESCRIPTION
This is a workaround, not an actual fix.

This workaround resolves #360 by skipping the metadata pool size check.

#360 caused by an issue where the metadata pool size not calculated correctly for  the volume-resize case.
A proper fix would need to calculate the correct metadata pool size and check.