### PR TITLE
Automatically fix symlinks for devices

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
@@ -37,6 +37,7 @@ import com.linbit.linstor.core.objects.Volume;
 import com.linbit.linstor.core.pojos.LocalPropsChangePojo;
 import com.linbit.linstor.dbdrivers.DatabaseException;
 import com.linbit.linstor.layer.DeviceLayer;
+import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
 import com.linbit.linstor.layer.drbd.drbdstate.DrbdConnection;
 import com.linbit.linstor.layer.drbd.drbdstate.DrbdEventPublisher;
 import com.linbit.linstor.layer.drbd.drbdstate.DrbdResource;
@@ -1141,6 +1142,18 @@ public class DrbdLayer implements DeviceLayer
         {
             // internal meta data
             metaDiskPath = drbdVlmData.getDataDevice();
+        }
+
+        if (!Files.exists(Paths.get(metaDiskPath))) {
+            errorReporter.logWarning("Device path %s does not exists, fixing symlink", metaDiskPath);
+            try
+            {
+                DmSetupUtils.fixSymlinkForDevice(extCmdFactory.create(), metaDiskPath);
+            }
+            catch (StorageException exc)
+            {
+                errorReporter.reportError(exc);
+            }
         }
 
         MdSuperblockBuffer mdUtils = new MdSuperblockBuffer();


### PR DESCRIPTION
## Overview
    This change is workaround for specific set of issues, often related to udev,
    which lead to the disappearance of symlinks for LVM devices on a working system.
    These issues commonly occur during device resizing and deactivation,
    causing LINSTOR expceptions diring accessing DRBD super-block of volume.

## Changes Made
    Introduce an additional handler that checks for the device path before each such modification.
    If the device is not found, it attempts to fix the symlink using dmsetup output.

## Related Issue
fixes: https://github.com/LINBIT/linstor-server/issues/326