### PR TITLE
Add Prometheus metrics exposing TcpPortAutoRange values

### DIFF
--- a/server/src/main/java/com/linbit/linstor/numberpool/DynamicNumberPool.java
+++ b/server/src/main/java/com/linbit/linstor/numberpool/DynamicNumberPool.java
@@ -19,5 +19,9 @@ public interface DynamicNumberPool
     int autoAllocate()
         throws ExhaustedPoolException;
 
+    int getRangeMin();
+
+    int getRangeMax();
+
     void deallocate(int nr);
 }

--- a/server/src/main/java/com/linbit/linstor/numberpool/DynamicNumberPoolImpl.java
+++ b/server/src/main/java/com/linbit/linstor/numberpool/DynamicNumberPoolImpl.java
@@ -141,6 +141,12 @@ public class DynamicNumberPoolImpl implements DynamicNumberPool
         numberPool.deallocate(nr);
     }
 
+    @Override
+    public int getRangeMin() { return rangeMin; }
+
+    @Override
+    public int getRangeMax() { return rangeMax; }
+
     public interface NumberRangeChecker
     {
         void check(Integer integer)

--- a/server/src/main/java/com/linbit/linstor/numberpool/SatelliteDynamicNumberPool.java
+++ b/server/src/main/java/com/linbit/linstor/numberpool/SatelliteDynamicNumberPool.java
@@ -38,4 +38,10 @@ public class SatelliteDynamicNumberPool implements DynamicNumberPool
     {
         // no-op
     }
+
+    @Override
+    public int getRangeMin() { return 0; }
+
+    @Override
+    public int getRangeMax() { return 0; }
 }

--- a/src/test/java/com/linbit/linstor/prometheus/PrometheusBuilderTest.java
+++ b/src/test/java/com/linbit/linstor/prometheus/PrometheusBuilderTest.java
@@ -36,6 +36,8 @@ public class PrometheusBuilderTest
                 start);
         Assert.assertNotNull(promText);
         Assert.assertTrue(promText.contains("linstor_scrape_requests_count"));
+        Assert.assertTrue(promText.contains("linstor_controller_tcp_port_auto_range_min"));
+        Assert.assertTrue(promText.contains("linstor_controller_tcp_port_auto_range_max"));
     }
 
     @Test


### PR DESCRIPTION
Closes #449.

The feature itself is still in discussion, but I was looking around the source code and thought it was simple enough to attempt a first implementation.
I've validated the behavior E2E:

```
root@server01:~# curl http://localhost:3370/metrics -s | grep tcp_port
# TYPE linstor_controller_tcp_port_auto_range_min gauge
linstor_controller_tcp_port_auto_range_min 7000.0
# TYPE linstor_controller_tcp_port_auto_range_max gauge
linstor_controller_tcp_port_auto_range_max 7999.0
root@server01:~# linstor controller sp TcpPortAutoRange 6000-9000
SUCCESS:
    The TCP port range was successfully updated to: 6000-9000
SUCCESS:
    Successfully set property 'TcpPortAutoRange' to value '6000-9000'
root@server01:~# curl http://localhost:3370/metrics -s | grep tcp_port
# TYPE linstor_controller_tcp_port_auto_range_min gauge
linstor_controller_tcp_port_auto_range_min 6000.0
# TYPE linstor_controller_tcp_port_auto_range_max gauge
linstor_controller_tcp_port_auto_range_max 9000.0
```

Please let me know if any changes or further validations are required. Thanks!