### PR TITLE
fix(drbd): use actual device path in res file during toggle-disk

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/resfiles/ConfFileBuilder.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/resfiles/ConfFileBuilder.java
@@ -894,12 +894,16 @@ public class ConfFileBuilder
         if (((Volume) vlmData.getVolume()).getFlags().isUnset(localAccCtx, Volume.Flags.DELETE))
         {
             final String disk;
+            // Check if we're in toggle-disk operation (adding disk to diskless resource)
+            boolean isDiskAdding = vlmData.getVolume().getAbsResource().getStateFlags().isSomeSet(
+                localAccCtx, Resource.Flags.DISK_ADD_REQUESTED, Resource.Flags.DISK_ADDING);
             if ((!isPeerRsc && vlmData.getDataDevice() == null) ||
                 (isPeerRsc &&
                 // FIXME: vlmData.getRscLayerObject().getFlags should be used here
                      vlmData.getVolume().getAbsResource().disklessForDrbdPeers(accCtx)
                 ) ||
-                (!isPeerRsc &&
+                // For toggle-disk: if dataDevice is set and we're adding disk, use the actual device
+                (!isPeerRsc && !isDiskAdding &&
                 // FIXME: vlmData.getRscLayerObject().getFlags should be used here
                      vlmData.getVolume().getAbsResource().isDrbdDiskless(accCtx)
                 )


### PR DESCRIPTION
## Summary
- Fix res file generation during toggle-disk operation from diskless to diskful
- Add check for DISK_ADD_REQUESTED/DISK_ADDING flags to use actual device path instead of "none"

## Problem
When converting a diskless resource to diskful via `toggle-disk -s <storage-pool>`, the res file generator outputs `disk none` because `isDrbdDiskless()` returns true until the operation completes. This causes `drbdadm adjust` to fail as the res file doesn't reflect the actual storage device already created by the storage layer.

## Solution
Check for `DISK_ADD_REQUESTED` or `DISK_ADDING` flags and use the actual device path when toggle-disk operation is in progress.

## Test plan
- [x] Create diskless DRBD resource with LUKS encryption
- [x] Run `toggle-disk -s <storage-pool>` to convert to diskful
- [x] Verify res file contains actual device path, not "none"
- [x] Verify drbdadm adjust succeeds