### PR TITLE
Fix: Skip DRBD adjust/res file regeneration when child layer device is inaccessible

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java
+++ b/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java
@@ -87,6 +87,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Singleton
 public class DeviceHandlerImpl implements DeviceHandler
@@ -1719,7 +1721,10 @@ public class DeviceHandlerImpl implements DeviceHandler
     private void updateDiscGran(VlmProviderObject<Resource> vlmData) throws DatabaseException, StorageException
     {
         @Nullable String devicePath = vlmData.getDevicePath();
-        if (devicePath != null && vlmData.exists())
+        // Check if device path physically exists before calling lsblk
+        // This is important for DRBD devices which might be temporarily unavailable during adjust
+        // (drbdadm adjust brings devices down/up, and kernel might not have created the device node yet)
+        if (devicePath != null && vlmData.exists() && Files.exists(Paths.get(devicePath)))
         {
             if (vlmData.getDiscGran() == VlmProviderObject.UNINITIALIZED_SIZE)
             {

--- a/satellite/src/main/java/com/linbit/linstor/layer/luks/LuksLayer.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/luks/LuksLayer.java
@@ -405,6 +405,7 @@ public class LuksLayer implements DeviceLayer
                 vlmData.setSizeState(Size.AS_EXPECTED);
 
                 vlmData.setOpened(true);
+                vlmData.setExists(true);
                 vlmData.setFailed(false);
             }
         }


### PR DESCRIPTION
fixes https://github.com/LINBIT/linstor-server/issues/350#issuecomment-3658026750

## Problem

This PR fixes three related issues with device availability checks in DRBD layer:

### 1. Resources stuck in StandAlone after node reboot

After node reboot, DRBD resources remain in StandAlone state instead of automatically reconnecting because child device availability checks block network reconnection operations that don't require disk access.

### 2. Resources end up in Unknown state after satellite restart  

Race condition when `drbdadm adjust` temporarily brings devices down/up: the kernel hasn't created `/dev/drbd*` device nodes yet, but `updateDiscGran()` immediately tries to run `lsblk`, which fails and interrupts the DeviceManager cycle.

### 3. Encrypted resource deletion fails

When deleting LUKS-encrypted resources, the LUKS layer may close its device before the DRBD layer attempts to adjust or regenerate the res file, causing 'Failed to adjust DRBD resource' errors.

## Solution

### Commit 1: Skip DRBD operations when child devices are inaccessible during deletion

Add checks before `regenerateResFile()` and `drbdUtils.adjust()` to verify child layer devices are accessible. If devices don't exist (e.g., LUKS closed during deletion), skip operations and clear `adjustRequired` flag.

### Commit 2: Skip lsblk when device path doesn't physically exist

Check `Files.exists(devicePath)` before calling `lsblk` in `updateDiscGran()`. If device node doesn't exist yet, skip the check - it will retry in the next DeviceManager cycle.

### Commit 3: Only check child devices when disk access is needed

Distinguish between operations requiring disk access (volume creation, resize, metadata) and those that don't (network reconnect from StandAlone). Only check child device accessibility for disk operations, allowing automatic reconnection after reboot.

## Testing

- Encrypted (LUKS) resources deletion now completes successfully
- DRBD resources automatically reconnect from StandAlone after node reboot
- No more Unknown state resources after satellite restart with `drbdadm adjust` race conditions