### PR TITLE
netcom: Fix NPE in establishConnection when peer is null

### DIFF
--- a/server/src/main/java/com/linbit/linstor/netcom/TcpConnectorService.java
+++ b/server/src/main/java/com/linbit/linstor/netcom/TcpConnectorService.java
@@ -997,7 +997,7 @@ public class TcpConnectorService implements Runnable, TcpConnector
             String localAddrText = null;
             String remoteAddrText = null;
 
-            try
+            if (localAddr instanceof InetSocketAddress)
             {
                 final InetSocketAddress localInetAddr = (InetSocketAddress) localAddr;
                 final InetAddress ipAddress = localInetAddr.getAddress();
@@ -1006,12 +1006,8 @@ public class TcpConnectorService implements Runnable, TcpConnector
                     localAddrText = ipAddress.getHostAddress();
                 }
             }
-            catch (ClassCastException ignored)
-            {
-                // ignored
-            }
 
-            try
+            if (remoteAddr instanceof InetSocketAddress)
             {
                 final InetSocketAddress remoteInetAddr = (InetSocketAddress) remoteAddr;
                 final InetAddress ipAddress = remoteInetAddr.getAddress();
@@ -1019,10 +1015,6 @@ public class TcpConnectorService implements Runnable, TcpConnector
                 {
                     remoteAddrText = ipAddress.getHostAddress();
                 }
-            }
-            catch (ClassCastException ignored)
-            {
-                // ignored
             }
 
             final String errorDescription =


### PR DESCRIPTION
## Problem

When `establishConnection()` is called with a `SelectionKey` that has no attached `Peer` object, the code attempts to extract diagnostic information from the channel's addresses. However, `channel.getLocalAddress()` and `channel.getRemoteAddress()` can return `null`, causing a `NullPointerException` at line 1003.

This can occur during a race condition between connection cleanup and reconnect attempts, where the peer attachment is removed while an `OP_CONNECT` event is still pending in the selector.

The unhandled NPE kills the entire `SslConnector` thread, preventing all further outbound SSL connections until the controller is restarted.

## Fix

Replace the `try-catch (ClassCastException)` pattern with `instanceof` checks, which properly handle both `null` values and non-`InetSocketAddress` types.