### PR TITLE
Autoplacer,block-size: Consider resource group properties for initial min-IO size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed auto block-size not considering resource group and controller properties for initial min-IO size
 - Fixed resource definition delete setting DELETE flag when resources are still in use
 - Fixed retry deletion of already deleting resource (no longer fails if it is the second to last diskful resource)
 - Satellite now properly merges remote nodes + their data (props, netIfs)

--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscCrtApiHelper.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscCrtApiHelper.java
@@ -647,6 +647,42 @@ public class CtrlRscCrtApiHelper
                 }
 
                 final boolean autoMinIoSizeForVlmDfn = minIoSizeHelper.isAutoMinIoSize(vlmDfn, apiCtx);
+
+                // Consider configured block-size from resource group / volume group hierarchy
+                // so that volumes on storage pools with smaller min-IO size (e.g. 512) are created
+                // with the larger configured block-size (e.g. 4096), enabling later placement on
+                // storage pools with larger min-IO size
+                long effectiveBlockSize = poolBlockSize;
+                if (autoMinIoSizeForVlmDfn && vlmBlockSizeStr == null)
+                {
+                    final PriorityProps blockSizePrioProps = new PriorityProps(
+                        vlmDfn.getProps(apiCtx),
+                        rscDfn.getProps(apiCtx),
+                        rscDfn.getResourceGroup().getVolumeGroupProps(apiCtx, vlmDfn.getVolumeNumber()),
+                        rscDfn.getResourceGroup().getProps(apiCtx),
+                        ctrlPropsHelper.getStltPropsForView()
+                    );
+                    final @Nullable String cfgBlockSizeStr = blockSizePrioProps.getProp(
+                        InternalApiConsts.KEY_DRBD_BLOCK_SIZE,
+                        ApiConsts.NAMESPC_DRBD_DISK_OPTIONS
+                    );
+                    if (cfgBlockSizeStr != null)
+                    {
+                        try
+                        {
+                            final long cfgBlockSize = MathUtils.bounds(
+                                BlockSizeConsts.MIN_IO_SIZE,
+                                Long.parseLong(cfgBlockSizeStr),
+                                BlockSizeConsts.MAX_IO_SIZE
+                            );
+                            effectiveBlockSize = Math.max(poolBlockSize, cfgBlockSize);
+                        }
+                        catch (NumberFormatException ignored)
+                        {
+                        }
+                    }
+                }
+
                 boolean minIoNeedsUpdate;
                 if (vlmBlockSizeStr == null)
                 {
@@ -663,7 +699,7 @@ public class CtrlRscCrtApiHelper
                     if (canChangeMinIo)
                     {
                         // Set the changed minIoSize
-                        vlmDfn.setMinIoSize(poolBlockSize, apiCtx);
+                        vlmDfn.setMinIoSize(effectiveBlockSize, apiCtx);
                         if (rscDfn.getResourceCount() > 1)
                         {
                             // Only enable the "restart DRBD" property if this is NOT the very first resource we are


### PR DESCRIPTION
When auto-block-size determines the initial block-size for a new volume definition, it only considers the storage pool's hardware min-IO size. If the resource group or volume group has a larger DrbdOptions/Disk/block-size configured, it is ignored because the volume definition is created with empty properties and rscMinIoSizeCheck() only reads from the volume definition directly.

This causes problems on clusters with mixed sector sizes (e.g. 512-byte and 4096-byte disks): the autoplacer picks nodes with the most free space (typically the 512-byte nodes), sets block-size=512 on the volume definition, and then later adding a 4096-byte node fails with "incompatible minimum I/O size" - even though block-size=4096 is explicitly configured on the resource group.

Fix by consulting the PriorityProps hierarchy (resource definition, volume group, resource group) when initially setting the block-size, and using max(pool min-IO size, configured block-size) as the effective value.