### PR TITLE
auto-verify-algo: Do not clear property when no satellites have completed full sync

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscDfnAutoVerifyAlgoHelper.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscDfnAutoVerifyAlgoHelper.java
@@ -220,13 +220,17 @@ public class CtrlRscDfnAutoVerifyAlgoHelper implements CtrlRscAutoHelper.AutoHel
                 }
                 else
                 {
-                    final String msg = String.format("No common DRBD verify algorithm found for '%s', clearing prop",
-                        rscDfn.getName());
-                    errorReporter.logInfo(msg);
-                    final Props rscDfnProps = rscDfn.getProps(peerCtx);
-                    rscDfnProps.removeProp(InternalApiConsts.DRBD_AUTO_VERIFY_ALGO, ApiConsts.NAMESPC_DRBD_OPTIONS);
-                    touchedResources.addAll(rscDfn.streamResource(
-                        peerCtxProvider.get()).collect(Collectors.toList()));
+                    if (nodeCryptos.size() != 1)
+                    {
+                        final String msg = String.format(
+                            "No common DRBD verify algorithm found for '%s', clearing prop",
+                            rscDfn.getName());
+                        errorReporter.logInfo(msg);
+                        final Props rscDfnProps = rscDfn.getProps(peerCtx);
+                        rscDfnProps.removeProp(InternalApiConsts.DRBD_AUTO_VERIFY_ALGO, ApiConsts.NAMESPC_DRBD_OPTIONS);
+                        touchedResources.addAll(rscDfn.streamResource(
+                            peerCtxProvider.get()).toList());
+                    }
                 }
             }
             else


### PR DESCRIPTION
## Summary

`updateVerifyAlgorithm()` removes the `auto-verify-alg` property from a resource definition when `commonCryptoType()` returns null. This also happens when `nodeCryptos` is empty because no satellite has completed its full sync yet — e.g. during a cluster reboot. Removing the property causes `ConfFileBuilder` to generate `.res` files without `shared-secret`, breaking DRBD peer authentication.

## Steps to reproduce

Setup: 5-node RPi4 cluster, LINSTOR controller on master0. Resource "omada" has diskful replicas on node0, node1, node3 — notably **not** on the controller node master0.

1. All nodes are rebooted (full cluster restart)
2. LINSTOR controller starts on master0
3. First satellite reconnects → `CtrlNodeApiCallHandler` triggers `ctrlRscAutoHelper.manageAll()` for all resource definitions
4. `CtrlRscDfnAutoVerifyAlgoHelper.updateVerifyAlgorithm()` runs for "omada"
5. `getCryptoEntryMap()` filters by `peer.isFullSyncApplied()` — none of omada's nodes (node0, node1, node3) have completed full sync yet → empty map
6. `ProcCryptoUtils.commonCryptoType()` returns `null` for an empty map
7. `auto-verify-alg` is **removed** from the resource definition (line 227)
8. Satellite configs are regenerated: `ConfFileBuilder` sees `autoVerifyAlgo == null` → `supportsCramHmac = false` → `.res` files written **without** `cram-hmac-alg` and `shared-secret`
9. Later, remaining satellites complete full sync → `manageAll()` runs again → `auto-verify-alg` is restored → new `.res` files include the secret
10. Result: some nodes have `.res` with shared-secret, others without → `"Authentication of peer failed"` → connections fall back to `StandAlone`

Resources that have a replica on the controller node (master0) are not affected because the controller-local satellite completes full sync almost immediately, so `nodeCryptos` is never empty for those resources.

## Fix

Only clear `auto-verify-alg` when there are actual connected nodes that lack a common hash algorithm. Skip the removal when the node map is empty (no satellites connected yet).