### PR TITLE
fix(drbd): use DrbdRscData flags for diskless detection in ConfFileBuilder

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/resfiles/ConfFileBuilder.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/resfiles/ConfFileBuilder.java
@@ -35,6 +35,7 @@ import com.linbit.linstor.security.AccessContext;
 import com.linbit.linstor.security.AccessDeniedException;
 import com.linbit.linstor.storage.StorageException;
 import com.linbit.linstor.storage.data.adapter.drbd.DrbdRscData;
+import com.linbit.linstor.storage.interfaces.layers.drbd.DrbdRscObject;
 import com.linbit.linstor.storage.data.adapter.drbd.DrbdRscDfnData;
 import com.linbit.linstor.storage.data.adapter.drbd.DrbdVlmData;
 import com.linbit.linstor.storage.interfaces.categories.resource.AbsRscLayerObject;
@@ -868,15 +869,11 @@ public class ConfFileBuilder
         if (((Volume) vlmData.getVolume()).getFlags().isUnset(localAccCtx, Volume.Flags.DELETE))
         {
             final String disk;
+            boolean isDrbdLayerDiskless = vlmData.getRscLayerObject().getFlags()
+                .isSet(localAccCtx, DrbdRscObject.DrbdRscFlags.DISKLESS);
             if ((!isPeerRsc && vlmData.getDataDevice() == null) ||
-                (isPeerRsc &&
-                // FIXME: vlmData.getRscLayerObject().getFlags should be used here
-                     vlmData.getVolume().getAbsResource().disklessForDrbdPeers(accCtx)
-                ) ||
-                (!isPeerRsc &&
-                // FIXME: vlmData.getRscLayerObject().getFlags should be used here
-                     vlmData.getVolume().getAbsResource().isDrbdDiskless(accCtx)
-                )
+                (isPeerRsc && isDrbdLayerDiskless) ||
+                (!isPeerRsc && isDrbdLayerDiskless)
             )
             {
                 disk = "none";


### PR DESCRIPTION
## Summary

The satellite's ConfFileBuilder uses Resource-level flags (`disklessForDrbdPeers()` / `isDrbdDiskless()`) to determine whether a peer should have `disk none` in the generated .res file. These flags can be stale on the satellite for remote resources, causing incorrect .res generation after toggle-disk operations.

## Root Cause

After a toggle-disk operation, the controller updates `DrbdRscData` flags (layer level) but the `Resource`-level flags for remote peers on the satellite may not be refreshed. ConfFileBuilder was reading the stale Resource flags, generating `disk none` for peers that actually have disks.

Two FIXME comments in the code already identified this exact issue:
```java
// FIXME: vlmData.getRscLayerObject().getFlags should be used here
```

## Fix

Replace `Resource.disklessForDrbdPeers()` and `Resource.isDrbdDiskless()` calls with `DrbdRscData.flags.isSet(DISKLESS)` — the layer-level flags that are reliably updated during every merge from the controller.

## Symptoms

- DRBD log: `The peer is configured to be diskless but presents UpToDate`
- Peers stuck in `Connecting` or `StandAlone` state after toggle-disk
- `.res` files showing `disk none` for diskful peers