### PR TITLE
feat: add StorDriver/LvcreatePvSelection prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upated debian package compat version to 11
 - linstor-controller.service: switch to DynamicUser (i.e., execute as non-root user).
 - Systemd-notify: Use SDNotify library instead of calling "systemd-notify"
+- Thick LVM: New volumes are now placed on the least-used PVs by default. This behavior can be customized via the new "StorDriver/LvcreatePvSelection" property.
 
 ### Removed
 

--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/LvmProvider.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/LvmProvider.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 @Singleton
 public class LvmProvider
@@ -291,8 +292,16 @@ public class LvmProvider
         throws StorageException, AccessDeniedException, DatabaseException
     {
         List<String> additionalOptions = ShellUtils.shellSplit(getLvcreateOptions(vlmData));
-        String[] additionalOptionsArr = new String[additionalOptions.size()];
-        additionalOptions.toArray(additionalOptionsArr);
+        Stream<String> additionalOptionsStream = additionalOptions.stream();
+        List<String> pvSelection = ShellUtils.shellSplit(getLvcreatePvSelection(vlmData));
+        if (!pvSelection.isEmpty())
+        {
+            additionalOptionsStream = Stream.concat(
+                additionalOptionsStream,
+                LvmUtils.getPhysicalVolumes(extCmdFactory, vlmData.getVolumeGroup(), pvSelection).stream()
+            );
+        }
+        String[] additionalOptionsArr = additionalOptionsStream.toArray(String[]::new);
 
         if (additionalOptions.contains("--config"))
         {
@@ -408,6 +417,16 @@ public class LvmProvider
             ApiConsts.NAMESPC_STORAGE_DRIVER,
             ApiConsts.KEY_STOR_POOL_LVCREATE_OPTIONS,
             ""
+        );
+    }
+
+    protected String getLvcreatePvSelection(LvmData<Resource> vlmDataRef)
+    {
+        return getProp(
+            vlmDataRef,
+            ApiConsts.NAMESPC_STORAGE_DRIVER,
+            ApiConsts.KEY_STOR_POOL_LVCREATE_PV_SELECTION,
+            "--sort pv_used"
         );
     }
 

--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/utils/LvmCommands.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/utils/LvmCommands.java
@@ -603,7 +603,12 @@ public class LvmCommands
         );
     }
 
-    public static synchronized OutputData listPhysicalVolumes(ExtCmd extCmdRef, String volumeGroupRef, String lvmConfig)
+    public static synchronized OutputData listPhysicalVolumes(
+        ExtCmd extCmdRef,
+        String volumeGroupRef,
+        String lvmConfig,
+        Collection<String> options
+    )
         throws StorageException
     {
         final String failMsg = "Failed to get physical devices for volume group: " + volumeGroupRef;
@@ -612,7 +617,7 @@ public class LvmCommands
             buildCmd(
                 "pvdisplay",
                 LVM_CONF_IGNORE_DRBD_DEVICES, // always ignore DRBD devices
-                (Collection<String>) null,
+                options,
                 "--columns",
                 "-o", "pv_name",
                 "-S", "vg_name=" + volumeGroupRef,
@@ -622,6 +627,12 @@ public class LvmCommands
             failMsg,
             failMsg
         );
+    }
+
+    public static synchronized OutputData listPhysicalVolumes(ExtCmd extCmdRef, String volumeGroupRef, String lvmConfig)
+        throws StorageException
+    {
+        return listPhysicalVolumes(extCmdRef, volumeGroupRef, lvmConfig, null);
     }
 
 

--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/utils/LvmUtils.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/lvm/utils/LvmUtils.java
@@ -686,13 +686,17 @@ public class LvmUtils
         }
     }
 
-    public static List<String> getPhysicalVolumes(ExtCmdFactory extCmdFactory, String volumeGroup)
+    public static List<String> getPhysicalVolumes(
+        ExtCmdFactory extCmdFactory,
+        String volumeGroup,
+        Collection<String> options
+    )
         throws StorageException
     {
         // no lvm config here. this method is used to build the --config param. using execWithRetry here would cause an
         // endless-recursion!
 
-        final OutputData output = LvmCommands.listPhysicalVolumes(extCmdFactory.create(), volumeGroup, "");
+        final OutputData output = LvmCommands.listPhysicalVolumes(extCmdFactory.create(), volumeGroup, "", options);
         final String stdOut = new String(output.stdoutData, StandardCharsets.UTF_8);
         final List<String> pvs = new ArrayList<>();
         final String[] lines = StringUtils.split(stdOut, "\n");
@@ -705,6 +709,12 @@ public class LvmUtils
             }
         }
         return pvs;
+    }
+
+    public static List<String> getPhysicalVolumes(ExtCmdFactory extCmdFactory, String volumeGroup)
+        throws StorageException
+    {
+        return getPhysicalVolumes(extCmdFactory, volumeGroup, null);
     }
 
     public static OutputData execWithRetry(


### PR DESCRIPTION
This PR adds the `StorDriver/LvcreatePvsOptions` property. When configured, the specified PV list is appended to every lvcreate command. For example, setting `StorDriver/LvcreatePvsOptions=--sort -pv_free` allows for the even distribution of LVs across PVs.

This PR requires https://github.com/LINBIT/linstor-common/pull/4.