### PR TITLE
Exempt special satellites from the uname uniqueness check

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/internal/CtrlAuthResponseApiCallHandler.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/internal/CtrlAuthResponseApiCallHandler.java
@@ -120,47 +120,54 @@ public class CtrlAuthResponseApiCallHandler
         throws InvalidValueException, DatabaseException
     {
         Node node = peer.getNode();
-        Props nodeProps = node.getProps();
-        @Nullable String oldUname = nodeProps.getProp(InternalApiConsts.NODE_UNAME);
-        @Nullable NodeName curNodeName = nodeRepo.getUname(nodeUname);
-        if (!nodeUname.equals(oldUname))
+        /*
+         * Special satellites run within the controller's process and therefore all report the
+         * controller's uname. They also never take part in DRBD, so the uname map (mapping DRBD
+         * peer unames to node names) does not apply to them.
+         */
+        if (!node.getNodeType().isSpecial())
         {
-            if (oldUname != null)
+            Props nodeProps = node.getProps();
+            @Nullable String oldUname = nodeProps.getProp(InternalApiConsts.NODE_UNAME);
+            @Nullable NodeName curNodeName = nodeRepo.getUname(nodeUname);
+            if (!nodeUname.equals(oldUname))
             {
-                // uname change, cleanup old uname
-                nodeRepo.removeUname(oldUname);
-            }
-            if (curNodeName != null)
-            {
-                peer.setAuthenticated(false);
-                peer.setConnectionStatus(ApiConsts.ConnectionStatus.DUPLICATE_UNAME);
-                errorReporter.reportError(
-                    Level.ERROR,
-                    new InvalidNameException(
-                        String.format(
-                            "Satellite has an uname '%s' that is already used by a different satellite '%s'",
-                            nodeUname,
-                            curNodeName),
-                        nodeUname
-                    )
-                );
+                if (oldUname != null)
+                {
+                    // uname change, cleanup old uname
+                    nodeRepo.removeUname(oldUname);
+                }
+                if (curNodeName != null)
+                {
+                    peer.setAuthenticated(false);
+                    peer.setConnectionStatus(ApiConsts.ConnectionStatus.DUPLICATE_UNAME);
+                    errorReporter.reportError(
+                        Level.ERROR,
+                        new InvalidNameException(
+                            String.format(
+                                "Satellite has an uname '%s' that is already used by a different satellite '%s'",
+                                nodeUname,
+                                curNodeName),
+                            nodeUname
+                        )
+                    );
+                }
+                else
+                {
+                    // new node added
+                    nodeProps.setProp(InternalApiConsts.NODE_UNAME, nodeUname);
+                    nodeRepo.putUname(nodeUname, node.getName());
+                }
             }
             else
             {
-                // new node added
-                nodeProps.setProp(InternalApiConsts.NODE_UNAME, nodeUname);
-                nodeRepo.putUname(nodeUname, node.getName());
+                if (curNodeName == null)
+                {
+                    // reconnect node
+                    nodeRepo.putUname(nodeUname, node.getName());
+                }
             }
         }
-        else
-        {
-            if (curNodeName == null)
-            {
-                // reconnect node
-                nodeRepo.putUname(nodeUname, node.getName());
-            }
-        }
-
     }
 
     private Flux<ApiCallRc> authResponseInTransaction(


### PR DESCRIPTION
Fixes #505.

### Problem

Since the uname map was introduced (v1.31.1), only the first special satellite (e.g. `EBS_TARGET`) can authenticate. Special satellites run within the controller's process, so `CtrlAuth` reports the controller's uname (`LinStor.getHostName()`) for all of them, and `updateUnameMap()` de-authenticates every one after the first with `DUPLICATE_UNAME`. This makes the documented multi-AZ native-EBS setup (one EBS target per AZ) impossible to bootstrap on any release ≥ 1.31.1. Details in #505.

### Fix

Skip the uname-map update and the uniqueness check for special node types. Special satellites never take part in DRBD, so the uname map — whose purpose is mapping DRBD peer unames to node names for replication-state reporting — does not apply to them. This mirrors the existing `isSpecial()` exemption for the node-name-mismatch info message a few lines below in the same class.

### Testing

- `:controller:compileJava` + `:controller:checkstyleMain` clean (no new warnings).
- Behavior validated live on our cluster in the inverse direction: seeding the persisted `NodeUname` so the map check passes lets all three EBS targets connect and (on a version unaffected by #506) serve volumes correctly — confirming nothing downstream depends on distinct unames for special satellites.
- End-to-end validation of this patch (three `create-ebs-target` nodes all reaching Online without workarounds) planned via cherry-pick onto a working EBS baseline, as the EBS path on master is currently blocked by #506. Happy to report results here.
