### PR TITLE
FileProvider: Use a per-process unique temporary lodev file name

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/file/FileProvider.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/file/FileProvider.java
@@ -686,7 +686,12 @@ public class FileProvider extends AbsStorageProvider<FileInfo, FileData<Resource
             sb.append(entry.getKey()).append(":").append(entry.getValue()).append("\n");
         }
 
-        tmpName = platformStlt.sysRoot() + LODEV_FILE_TMP;
+        // Multiple satellite processes may share this directory, e.g. the special satellites
+        // that the controller spawns within its own container. A per-process unique temporary
+        // file name prevents concurrent device manager cycles of such satellites from moving
+        // each other's temporary file away, which fails the whole device manager cycle with a
+        // NoSuchFileException.
+        tmpName = platformStlt.sysRoot() + LODEV_FILE_TMP + "." + ProcessHandle.current().pid();
         lodevName = platformStlt.sysRoot() + LODEV_FILE;
 
         File tmp = new File(tmpName);


### PR DESCRIPTION
Fixes #511.

### Problem

Special satellites spawned by the controller (e.g. `EBS_TARGET` nodes) all run within the controller's container and share `/var/lib/linstor.d`. Every device-manager cycle ends in `FileProvider.clearCache()`, which writes `loop_device_mapping.tmp` and atomically renames it — even with zero loop devices. Concurrent cycles of co-located satellites race on the shared temp file: one renames it away, the other's rename throws `NoSuchFileException`, and that satellite's whole device-manager cycle aborts. With three per-AZ EBS targets this fires regularly and leaves freshly dispatched resources stuck `Unknown` (live evidence in #511).

### Fix

Use a per-process unique temporary file name (`loop_device_mapping.tmp.<pid>`), keeping the atomic-rename pattern while making co-located satellites' cycles independent. Behavior for the normal one-satellite-per-host case is unchanged.

### Testing

- `:satellite:compileJava` + `:satellite:checkstyleMain` clean (no new findings).
- End-to-end on the live reproducing cluster (3 EBS targets, arm64/K8s): being validated with a patched v1.34.1 image; results will be posted here.
