### PR TITLE
MakeAvailable: Do not force the DRBD client role onto EBS initiators

### DIFF
--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscCrtApiHelper.java
+++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscCrtApiHelper.java
@@ -435,7 +435,13 @@ public class CtrlRscCrtApiHelper
             boolean isNvmeInitiatorSet = FlagsHelper.isFlagEnabled(adjustedFlags, Resource.Flags.NVME_INITIATOR);
             boolean isEbsInitiatorSet = FlagsHelper.isFlagEnabled(adjustedFlags, Resource.Flags.EBS_INITIATOR);
 
-            if (drbdClientRef != null && drbdClientRef && (isStorPoolDiskless || storPool == null))
+            /*
+             * EBS initiators must not be turned into DRBD clients: their storage pool kind (EBS_INIT)
+             * has no backing device from LINSTOR's point of view, but the satellite attaches the EBS
+             * volume of a target replica locally, so the resource acts as a diskful DRBD node.
+             */
+            if (drbdClientRef != null && drbdClientRef && !isEbsInitiatorSet &&
+                (isStorPoolDiskless || storPool == null))
             {
                 adjustedFlags |= Resource.Flags.DRBD_DISKLESS.flagValue;
                 isDrbdDisklessSet = true;


### PR DESCRIPTION
Fixes #513.

`CtrlRscMakeAvailableApiCallHandler` hardcodes `drbdClient=true`; since `69eae9987` ("Drbd: Add client role", first in v1.34.0) `CtrlRscCrtApiHelper` coerces any resource on a backing-device-less storage pool into `DRBD_DISKLESS` + client. `EBS_INIT` pools report no backing device, so EBS initiator resources — despite make-available correctly selecting the `EBS_INITIATOR` diskless type — additionally received `DRBD_DISKLESS`, never bound a target EBS volume, and every mount failed. This makes EBS-backed CSI volumes unusable on v1.34.

Skip the coercion when the requested flags carry `EBS_INITIATOR`: the satellite attaches a target replica's EBS volume locally, so the resource acts as a diskful DRBD node, not a client.

Testing: `:controller:compileJava` + checkstyle clean; behavior validated live on the reproducing cluster — the identical resource created manually with `--ebs-initiator` (i.e. without the coerced flags) binds, attaches, syncs and mounts correctly; E2E of this patch on a v1.34.1-based build is running now, results to follow in #513.
