### PR TITLE
EbsUtils: Fall back to the SUCCESSFUL flag when snapshot state is unset

### DIFF
--- a/server/src/main/java/com/linbit/linstor/layer/storage/ebs/EbsUtils.java
+++ b/server/src/main/java/com/linbit/linstor/layer/storage/ebs/EbsUtils.java
@@ -13,6 +13,7 @@ import com.linbit.linstor.core.objects.AbsVolume;
 import com.linbit.linstor.core.objects.Node;
 import com.linbit.linstor.core.objects.Resource;
 import com.linbit.linstor.core.objects.Snapshot;
+import com.linbit.linstor.core.objects.SnapshotDefinition;
 import com.linbit.linstor.core.objects.SnapshotVolume;
 import com.linbit.linstor.core.objects.StorPool;
 import com.linbit.linstor.core.objects.Volume;
@@ -201,7 +202,23 @@ public class EbsUtils
         while (snapVlmIt.hasNext())
         {
             SnapshotVolume snapVlm = snapVlmIt.next();
-            allCompleted &= snapVlm.getState().equals(EBS_SNAP_STATE_COMPLETED);
+            @Nullable String state = snapVlm.getState();
+            if (state == null)
+            {
+                /*
+                 * The in-memory state is only populated by the EBS status poller, so it can be unset
+                 * right after the snapshot was taken or after a controller restart. A snapshot whose
+                 * creation flow finished (SUCCESSFUL flag) was already confirmed 'completed' by AWS
+                 * before the satellite reported success, so fall back to that flag.
+                 */
+                allCompleted &= snapshotRef.getSnapshotDefinition()
+                    .getFlags()
+                    .isSet(SnapshotDefinition.Flags.SUCCESSFUL);
+            }
+            else
+            {
+                allCompleted &= state.equals(EBS_SNAP_STATE_COMPLETED);
+            }
         }
         return allCompleted;
     }


### PR DESCRIPTION
Fixes #516.

`SnapshotVolume.state` is in-memory only and populated solely by `EbsStatusManagerService` polling, so it is legitimately unset right after snapshot creation and always unset after a controller restart. `EbsUtils.isSnapshotCompleted()` dereferenced it unconditionally, which made every EBS snapshot restore fail with an NPE.

Fall back to `SnapshotDefinition.Flags.SUCCESSFUL` when the state is unset: the EBS creation flow (`EbsProviderUtils.waitUntilSnapshotCreated`) only reports success once AWS confirms the snapshot is `completed`, so the flag is a reliable stand-in — and the only caller (`CtrlSnapshotHelper.ensureSnapshotSuccessful`) already rejects non-SUCCESSFUL snapshots one check earlier.

Testing: `:server:compileJava` clean; live E2E on our reproducing cluster (v1.34.1-based build): restore of a `Successful` snapshot proceeds past the previous NPE — results posted in #516.
