### PR TITLE
DrbdLayerUtils: Skip the initial sync for EBS-backed volumes

### DIFF
--- a/server/src/main/java/com/linbit/linstor/utils/layer/DrbdLayerUtils.java
+++ b/server/src/main/java/com/linbit/linstor/utils/layer/DrbdLayerUtils.java
@@ -111,7 +111,27 @@ public class DrbdLayerUtils
     public static boolean skipInitSync(DrbdVlmData<Resource> drbdVlmDataRef)
     {
         boolean skipInitSync;
-        if (DrbdLayerUtils.isForceInitialSyncSet(drbdVlmDataRef.getRscLayerObject()))
+        boolean allEbs = VolumeUtils.getStorageDevices(
+            drbdVlmDataRef.getChildBySuffix(RscLayerSuffixes.SUFFIX_DATA)
+        )
+            .stream()
+            .map(VlmProviderObject::getProviderKind)
+            .allMatch(
+                kind -> kind == DeviceProviderKind.EBS_INIT || kind == DeviceProviderKind.EBS_TARGET
+            );
+        if (allEbs)
+        {
+            /*
+             * Like thin volumes, freshly created EBS volumes are guaranteed to read as zeros, so all
+             * replicas start out identical and the initial sync can be skipped. For EBS the skip is
+             * also mandatory, even if an initial sync is forced (e.g. by the mixed-storage-pool
+             * detection): the initial-UpToDate node is an EBS target, which never creates DRBD
+             * meta-data locally, so no sync source can ever exist and an EBS initiator waiting for
+             * one would wait forever.
+             */
+            skipInitSync = true;
+        }
+        else if (DrbdLayerUtils.isForceInitialSyncSet(drbdVlmDataRef.getRscLayerObject()))
         {
             skipInitSync = false;
         }


### PR DESCRIPTION
Fixes #515.

The initial-UpToDate mechanism cannot work for EBS resources: `KEY_LINSTOR_DRBD_INITIAL_UPTODATE_ON` names a diskful node, which for EBS is an `EBS_TARGET` — but target satellites never create DRBD meta-data locally (their EBS volume is attached by the *initiator*), so `hasLocalStltWonUpToDateRace`'s winner-side skip never executes, and the initiator — a "loser" by node name — leaves its meta-data in just-created state and waits forever for a sync source that cannot exist. Every fresh EBS resource is stuck `Inconsistent` on all replicas and can never be promoted or mounted (live evidence in #515).

Extend the `skipInitSync` fallback to EBS-backed volumes: freshly created EBS volumes are guaranteed to read as zeros, so — exactly like the existing thin/ZFS cases — all replicas start out identical and the day0-GI skip is safe.

Testing: `:server:compileJava` + `:satellite:compileJava` clean; E2E on the live reproducing cluster (v1.34.1-based build with our EBS fix series): fresh CSI volume reaches UpToDate and mounts hands-free — results posted in #515.
