### PR TITLE
DrbdLayer: Run post-initialization (mkfs) on the EBS initiator

### DIFF
--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
@@ -60,6 +60,7 @@ import com.linbit.linstor.propscon.Props;
 import com.linbit.linstor.stateflags.StateFlags;
 import com.linbit.linstor.storage.StorageException;
 import com.linbit.linstor.storage.data.RscLayerSuffixes;
+import com.linbit.linstor.storage.kinds.DeviceProviderKind;
 import com.linbit.linstor.storage.data.adapter.drbd.DrbdRscData;
 import com.linbit.linstor.storage.data.adapter.drbd.DrbdVlmData;
 import com.linbit.linstor.storage.interfaces.categories.resource.AbsRscLayerObject;
@@ -954,7 +955,13 @@ public class DrbdLayer implements DeviceLayer
         List<Integer> initializedVlmNrList = new ArrayList<>();
         for (DrbdVlmData<Resource> drbdVlmData : drbdRscDataRef.getVlmLayerObjects().values())
         {
-            if (hasLocalStltWonUpToDateRace(drbdVlmData))
+            /*
+             * The mkfs (and the controller notification) run for the volume that becomes UpToDate
+             * first. For EBS that node is an EBS target, which never attaches the volume locally and
+             * therefore cannot create the filesystem; the EBS initiator is the only node that
+             * attaches the EBS volume, so run the post-initialization there instead.
+             */
+            if (hasLocalStltWonUpToDateRace(drbdVlmData) || isEbsInitiator(drbdVlmData))
             {
                 initializedVlmNrList.add(drbdVlmData.getVlmNr().value);
             }
@@ -1625,6 +1632,23 @@ public class DrbdLayer implements DeviceLayer
         {
             throw new ImplementationError(exc);
         }
+    }
+
+    private boolean isEbsInitiator(DrbdVlmData<Resource> drbdVlmDataRef)
+    {
+        VolumeDefinition vlmDfn = drbdVlmDataRef.getVolume().getVolumeDefinition();
+        boolean ret = false;
+        if (!vlmDfn.getFlags().isSet(VolumeDefinition.Flags.DRBD_INITIALIZED))
+        {
+            var storageDevices = VolumeUtils.getStorageDevices(
+                drbdVlmDataRef.getChildBySuffix(RscLayerSuffixes.SUFFIX_DATA)
+            );
+            ret = !storageDevices.isEmpty() &&
+                storageDevices.stream()
+                    .map(VlmProviderObject::getProviderKind)
+                    .allMatch(kind -> kind == DeviceProviderKind.EBS_INIT);
+        }
+        return ret;
     }
 
     private boolean hasLocalStltWonUpToDateRace(DrbdVlmData<Resource> drbdVlmDataRef)


### PR DESCRIPTION
Fixes piraeusdatastore/linstor-csi#473 (the missing mkfs is actually here in linstor-server, not in the CSI driver — linstor-csi delegates formatting to the satellite via the `Filesystem/Type` property).

`runPostInitializationIfNeeded` builds its list of volumes to initialize — controller notification **and mkfs** — from `hasLocalStltWonUpToDateRace`, i.e. the node the controller designated to become UpToDate first. For EBS that node is an `EBS_TARGET`, which never attaches the volume locally and therefore cannot create the filesystem; the `EBS_INITIATOR` is the only node that attaches the EBS volume. As a result the list is empty on the initiator, mkfs never runs, and every fresh EBS volume comes up without a filesystem — the first mount fails with `wrong fs type, bad option, bad superblock` until an mkfs is run by hand.

Also treat an EBS initiator volume as initialized so the post-initialization (notification + mkfs) runs there. This is the mkfs counterpart to the initial-sync skip in #518 — both were gated on winning the UpToDate race, which an EBS initiator never does.

Testing: `:satellite:compileJava` + checkstyle clean; validated live on the reproducing cluster (v1.34.1 + our EBS series): a fresh CSI EBS volume now comes up formatted and a pod mounts it with **no manual mkfs** — results in linstor-csi#473.
