### PR TITLE
satellite: wait for probe devices before reading block information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed resizing a volume in a shared storage pool with external locking, refused because of the wrong lock
   mode.
+- Fixed the block device info probe racing with udev: the temporary probe volume's device node is now awaited and the probe retried, so storage pools no longer silently miss their min/opt I/O size properties
 
 ## [1.35.0] - 2026-08-27
 

--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/AbsStorageProvider.java
+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/AbsStorageProvider.java
@@ -153,6 +153,8 @@ public abstract class AbsStorageProvider<
     }
 
     private static final long DFLT_WAIT_UNTIL_DEVICE_CREATED_TIMEOUT_IN_MS = 5000;
+    private static final int PROBE_VLM_ATTEMPTS = 3;
+    private static final long PROBE_VLM_RETRY_DELAY_IN_MS = 1000;
     protected static final int DFLT_STRIPES = 1;
     public static final long SIZE_OF_NOT_FOUND_STOR_POOL = ApiConsts.VAL_STOR_POOL_SPACE_NOT_FOUND;
 
@@ -173,6 +175,7 @@ public abstract class AbsStorageProvider<
     protected final Set<String> changedStoragePoolStrings = new HashSet<>();
     private final String typeDescr;
     private final FileSystemWatch fsWatch;
+    private final Object probeVlmLock = new Object();
     protected final DeviceProviderKind kind;
     private final DrbdInvalidateUtils drbdInvalidateUtils;
 
@@ -1860,8 +1863,8 @@ public abstract class AbsStorageProvider<
      * Updates block device information (min I/O size, optimal I/O size, discard granularity) for a storage pool.
      *
      * Examines the first volume that exists in the storage pool to determine the block device properties from sysfs.
-     * If no volumes exist, a temporary probe volume is created. The determined values are stored as storage pool
-     * properties and sent to the controller.
+     * If no usable device exists, a temporary probe volume is created where supported. The determined values are stored
+     * as storage pool properties and sent to the controller.
      *
      * @param storPoolObj The storage pool to operate on
      * @param propsChange A LocalPropsChangePojo object to use for sending the property update to the controller
@@ -1916,38 +1919,114 @@ public abstract class AbsStorageProvider<
                 {
                 }
             }
-            else if (CollectionUtils.isEmpty(vlmProviderList) && this instanceof ProbeVlmStorageProvider storPrv)
+            else if (this instanceof ProbeVlmStorageProvider storPrv)
             {
-                errorReporter.logDebug("updateBlockDeviceInfo: Don't have vlmProviderList, using temporary volumes");
-                try
-                {
-                    final @Nullable String storDevicePath = storPrv.createTmpProbeVlm(storPoolObj);
-                    try
-                    {
-                        updateBlockDeviceInfoByDevice(storPoolObj, storDevicePath, propsChange);
-                    }
-                    catch (IOException ignored)
-                    {
-                    }
-                }
-                catch (StorageException ignored)
-                {
-                    errorReporter.logDebug("updateBlockDeviceInfo: Temporary volume creation failed");
-                }
-                finally
-                {
-                    try
-                    {
-                        storPrv.deleteTmpProbeVlm(storPoolObj);
-                    }
-                    catch (StorageException ignored)
-                    {
-                        errorReporter.logDebug("updateBlockDeviceInfo: Temporary volume deletion failed");
-                    }
-                }
+                updateBlockDeviceInfoByProbeVlm(storPrv, storPoolObj, propsChange);
             }
         }
         errorReporter.logDebug("EXIT updateBlockDeviceInfo method");
+    }
+
+    private void updateBlockDeviceInfoByProbeVlm(
+        ProbeVlmStorageProvider storPrv,
+        StorPool storPoolObj,
+        LocalPropsChangePojo propsChange
+    )
+    {
+        // Providers use a fixed probe name. Keep creation, probing and cleanup in one critical section.
+        synchronized (probeVlmLock)
+        {
+            boolean haveInfo = false;
+            boolean interrupted = false;
+            String lastFailure = "";
+            int attempts = 0;
+            while (attempts < PROBE_VLM_ATTEMPTS && !haveInfo && !interrupted)
+            {
+                if (attempts > 0)
+                {
+                    try
+                    {
+                        Thread.sleep(PROBE_VLM_RETRY_DELAY_IN_MS);
+                    }
+                    catch (InterruptedException exc)
+                    {
+                        Thread.currentThread().interrupt();
+                        lastFailure = "interrupted before the next probe attempt";
+                        break;
+                    }
+                }
+                attempts++;
+                boolean created = false;
+                boolean cleaned = false;
+                try
+                {
+                    @Nullable String storDevicePath = storPrv.createTmpProbeVlm(storPoolObj);
+                    created = true;
+                    if (storDevicePath == null)
+                    {
+                        lastFailure = "temporary volume has no device path";
+                    }
+                    else
+                    {
+                        waitUntilDeviceCreated(storDevicePath, getWaitTimeoutAfterCreate(storPoolObj));
+                        updateBlockDeviceInfoByDevice(storPoolObj, storDevicePath, propsChange);
+                        haveInfo = true;
+                    }
+                }
+                catch (StorageException | IOException exc)
+                {
+                    lastFailure = exc.getMessage();
+                    interrupted = exc.getCause() instanceof InterruptedException ||
+                        Thread.currentThread().isInterrupted();
+                    errorReporter.logDebug(
+                        "Temporary volume %s attempt %d failed: %s",
+                        created ? "probe" : "creation",
+                        attempts,
+                        lastFailure
+                    );
+                }
+                finally
+                {
+                    // Only a volume that was actually created can and must be cleaned up; after a failed
+                    // creation there is nothing to delete and no point in further attempts.
+                    if (created)
+                    {
+                        try
+                        {
+                            storPrv.deleteTmpProbeVlm(storPoolObj);
+                            cleaned = true;
+                        }
+                        catch (StorageException exc)
+                        {
+                            interrupted |= exc.getCause() instanceof InterruptedException ||
+                                Thread.currentThread().isInterrupted();
+                            errorReporter.logWarning(
+                                "Failed to delete temporary probe volume for storage pool '%s': %s",
+                                storPoolObj.getName().displayValue,
+                                exc.getMessage()
+                            );
+                        }
+                    }
+                }
+                if (interrupted)
+                {
+                    Thread.currentThread().interrupt();
+                }
+                if (!created || !cleaned)
+                {
+                    break;
+                }
+            }
+            if (!haveInfo)
+            {
+                errorReporter.logWarning(
+                    "Could not determine block device information for storage pool '%s' after %d probe attempts: %s",
+                    storPoolObj.getName().displayValue,
+                    attempts,
+                    lastFailure
+                );
+            }
+        }
     }
 
     /**

--- a/satellite/src/test/java/com/linbit/fsevent/ProbeVolumeDeviceWaitTest.java
+++ b/satellite/src/test/java/com/linbit/fsevent/ProbeVolumeDeviceWaitTest.java
@@ -1,0 +1,497 @@
+package com.linbit.fsevent;
+
+import com.linbit.Platform;
+import com.linbit.linstor.core.identifier.StorPoolName;
+import com.linbit.linstor.core.objects.Resource;
+import com.linbit.linstor.core.objects.StorPool;
+import com.linbit.linstor.core.pojos.LocalPropsChangePojo;
+import com.linbit.linstor.layer.storage.AbsStorageProvider.AbsStorageProviderInit;
+import com.linbit.linstor.layer.storage.utils.BlockSizeInfo;
+import com.linbit.linstor.layer.storage.zfs.ZfsThinProvider;
+import com.linbit.linstor.logging.ErrorReporter;
+import com.linbit.linstor.propscon.Props;
+import com.linbit.linstor.storage.StorageConstants;
+import com.linbit.linstor.storage.StorageException;
+import com.linbit.linstor.storage.interfaces.categories.resource.VlmProviderObject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.when;
+
+public class ProbeVolumeDeviceWaitTest
+{
+    @Rule
+    public final TemporaryFolder directory = new TemporaryFolder();
+
+    @Rule
+    public final Timeout timeout = Timeout.seconds(15);
+
+    private FileSystemWatch watch;
+    private Path device;
+    private Path link;
+    private StorPool pool;
+    private ProbeProvider provider;
+    private ErrorReporter reporter;
+    private ScheduledExecutorService executor;
+    private MockedStatic<BlockSizeInfo> blockSizes;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        assumeTrue(Platform.isLinux());
+        device = directory.newFile("zd-test").toPath();
+        link = directory.getRoot().toPath().resolve("probe");
+        executor = Executors.newSingleThreadScheduledExecutor();
+        reporter = mock(ErrorReporter.class);
+        watch = new FileSystemWatch(reporter);
+        watch.start();
+        pool = mock(StorPool.class);
+        when(pool.getName()).thenReturn(new StorPoolName("data"));
+        when(pool.getVolumes()).thenReturn(Collections.emptyList());
+        when(pool.getProps()).thenReturn(mock(Props.class));
+        provider = new ProbeProvider(new AbsStorageProviderInit(
+            reporter, null, null, null, null, null, null, null, null, watch, null, null, null
+        ));
+        blockSizes = mockStatic(BlockSizeInfo.class);
+        blockSizes.when(() -> BlockSizeInfo.getPhysicalBlockSize(device)).thenAnswer(invocation ->
+        {
+            assertTrue("Probe must still exist while its properties are read", Files.exists(link));
+            return 4096L;
+        });
+        blockSizes.when(() -> BlockSizeInfo.getOptimalIoSize(device)).thenReturn(33554432L);
+        blockSizes.when(() -> BlockSizeInfo.getDiscardGranularity(device)).thenReturn(16384L);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if (blockSizes != null)
+        {
+            blockSizes.close();
+        }
+        if (executor != null)
+        {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        }
+        if (watch != null)
+        {
+            watch.shutdown(false);
+            watch.awaitShutdown(2000);
+            watch.cancelAllWatchKeys();
+        }
+    }
+
+    @Test
+    public void delayedDevicePublishesPropertiesBeforeCleanup() throws Exception
+    {
+        provider.delayMillis = 50;
+        assertPublished(probe());
+        assertCleaned(1);
+        assertEquals(0, warningCount());
+    }
+
+    @Test
+    public void existingProbeDevicePublishesProperties() throws Exception
+    {
+        assertPublished(probe());
+        assertCleaned(1);
+    }
+
+    @Test
+    public void missingDeviceTimesOutAndCleansEveryAttempt() throws Exception
+    {
+        provider.delayMillis = -1;
+        provider.timeoutMillis = 20;
+        assertTrue(probe().isEmpty());
+        assertCleaned(3);
+        assertEquals(1, warningCount());
+    }
+
+    @Test
+    public void failedCreationStopsRetriesWithoutCleanup() throws Exception
+    {
+        provider.failCreateTimes = Integer.MAX_VALUE;
+        assertTrue(probe().isEmpty());
+        assertEquals(1, provider.createCalls);
+        assertEquals(0, provider.deleteCalls);
+        assertEquals(1, warningCount());
+    }
+
+    @Test
+    public void creationFailureAfterTimedOutAttemptStopsRetries() throws Exception
+    {
+        provider.delayMillis = -1;
+        provider.timeoutMillis = 20;
+        provider.failCreateOnCall = 2;
+        assertTrue(probe().isEmpty());
+        assertEquals(2, provider.createCalls);
+        assertEquals(1, provider.deleteCalls);
+        assertEquals(1, warningCount());
+    }
+
+    @Test
+    public void nullProbePathDoesNotPublishProperties() throws Exception
+    {
+        provider.nullPath = true;
+        assertTrue(probe().isEmpty());
+        assertCleaned(3);
+        assertEquals(1, warningCount());
+    }
+
+    @Test
+    public void nullFirstPathDoesNotSkipUsableVolume() throws Exception
+    {
+        Files.createSymbolicLink(link, device);
+        doReturn(List.of(volume(null), volume(link))).when(pool).getVolumes();
+        assertPublished(probe());
+        assertEquals(0, provider.createCalls);
+        assertEquals(0, provider.deleteCalls);
+    }
+
+    @Test
+    public void missingFirstPathDoesNotSkipUsableVolume() throws Exception
+    {
+        Files.createSymbolicLink(link, device);
+        doReturn(List.of(volume(link.resolveSibling("missing")), volume(link))).when(pool).getVolumes();
+        assertPublished(probe());
+        assertEquals(0, provider.createCalls);
+        assertEquals(0, provider.deleteCalls);
+    }
+
+    @Test
+    public void allNullPathsFallBackToProbe() throws Exception
+    {
+        doReturn(List.of(volume(null))).when(pool).getVolumes();
+        provider.delayMillis = 50;
+        assertPublished(probe());
+        assertCleaned(1);
+    }
+
+    @Test
+    public void allMissingPathsFallBackToProbe() throws Exception
+    {
+        doReturn(List.of(
+            volume(link.resolveSibling("missing-a")), volume(link.resolveSibling("missing-b"))
+        )).when(pool).getVolumes();
+        provider.delayMillis = 50;
+        assertPublished(probe());
+        assertCleaned(1);
+    }
+
+    @Test
+    public void cleanupFailureAfterSuccessIsReported() throws Exception
+    {
+        provider.failDelete = true;
+        assertPublished(probe());
+        assertEquals(1, provider.createCalls);
+        assertEquals(1, provider.deleteCalls);
+        assertEquals(1, warningCount());
+    }
+
+    @Test
+    public void cleanupFailurePreventsAnotherCreationAttempt() throws Exception
+    {
+        provider.delayMillis = -1;
+        provider.timeoutMillis = 20;
+        provider.failDelete = true;
+        assertTrue(probe().isEmpty());
+        assertEquals(1, provider.createCalls);
+        assertEquals(1, provider.deleteCalls);
+        assertEquals(2, warningCount());
+    }
+
+    @Test
+    public void interruptedDeviceWaitCleansUpAndPreservesInterrupt() throws Exception
+    {
+        provider.delayMillis = -1;
+        Thread callingThread = Thread.currentThread();
+        executor.schedule(callingThread::interrupt, 50, TimeUnit.MILLISECONDS);
+        try
+        {
+            assertTrue(probe().isEmpty());
+            assertTrue(callingThread.isInterrupted());
+            assertCleaned(1);
+            assertEquals(1, warningCount());
+        }
+        finally
+        {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void interruptedRetryDelayDoesNotCreateAnotherProbe() throws Exception
+    {
+        provider.delayMillis = -1;
+        provider.timeoutMillis = 200;
+        Thread callingThread = Thread.currentThread();
+        executor.schedule(callingThread::interrupt, 300, TimeUnit.MILLISECONDS);
+        try
+        {
+            assertTrue(probe().isEmpty());
+            assertTrue(callingThread.isInterrupted());
+            assertCleaned(1);
+            assertEquals(1, warningCount());
+        }
+        finally
+        {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void interruptedCleanupPreservesInterruptAndStopsRetries() throws Exception
+    {
+        provider.delayMillis = -1;
+        provider.timeoutMillis = 20;
+        provider.interruptDelete = true;
+        try
+        {
+            assertTrue(probe().isEmpty());
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertEquals(1, provider.createCalls);
+            assertEquals(1, provider.deleteCalls);
+        }
+        finally
+        {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void interruptedProbeStopsWithoutRetryDelay() throws Exception
+    {
+        blockSizes.when(() -> BlockSizeInfo.getPhysicalBlockSize(device)).thenAnswer(invocation ->
+        {
+            Thread.currentThread().interrupt();
+            throw new IOException("probe read failed");
+        });
+        try
+        {
+            assertTrue(probe().isEmpty());
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertCleaned(1);
+            assertEquals(1, warningCount());
+            // The probe failure itself must end the loop. Without the interrupt-flag check the loop would
+            // only stop inside the retry sleep, and the reported reason would be the interrupted delay.
+            assertEquals("probe read failed", lastWarningFinalArgument());
+        }
+        finally
+        {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void concurrentProbesDoNotShareTheTemporaryVolume() throws Exception
+    {
+        provider.creationDelayMillis = 200;
+        ExecutorService callers = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Callable<LocalPropsChangePojo> call = () ->
+        {
+            ready.countDown();
+            start.await();
+            return probe();
+        };
+        try
+        {
+            Future<LocalPropsChangePojo> first = callers.submit(call);
+            Future<LocalPropsChangePojo> second = callers.submit(call);
+            assertTrue(ready.await(2, TimeUnit.SECONDS));
+            start.countDown();
+            assertFalse(first.get(10, TimeUnit.SECONDS).isEmpty());
+            assertFalse(second.get(10, TimeUnit.SECONDS).isEmpty());
+            assertEquals(1, provider.peakActiveProbes.get());
+            assertCleaned(2);
+        }
+        finally
+        {
+            callers.shutdownNow();
+            assertTrue(callers.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    private LocalPropsChangePojo probe()
+    {
+        LocalPropsChangePojo changes = new LocalPropsChangePojo();
+        provider.updateBlockDeviceInfo(pool, changes);
+        return changes;
+    }
+
+    private void assertPublished(LocalPropsChangePojo changesRef)
+    {
+        String namespace = StorageConstants.NAMESPACE_INTERNAL + '/';
+        assertEquals(Map.of(
+            namespace + StorageConstants.BLK_DEV_MIN_IO_SIZE, "4096",
+            namespace + StorageConstants.BLK_DEV_OPT_IO_SIZE, "33554432",
+            namespace + StorageConstants.BLK_DEV_DISC_GRAN, "16384"
+        ), changesRef.changedStorPoolProps.get(pool.getName()));
+    }
+
+    private void assertCleaned(int attemptsRef)
+    {
+        assertEquals(attemptsRef, provider.createCalls);
+        assertEquals(attemptsRef, provider.deleteCalls);
+        assertFalse(Files.exists(link));
+    }
+
+    @SuppressWarnings("unchecked")
+    private VlmProviderObject<Resource> volume(Path pathRef)
+    {
+        VlmProviderObject<Resource> volume = mock(VlmProviderObject.class);
+        when(volume.getDevicePath()).thenReturn(pathRef == null ? null : pathRef.toString());
+        return volume;
+    }
+
+    private long warningCount()
+    {
+        return mockingDetails(reporter).getInvocations().stream()
+            .filter(invocation -> invocation.getMethod().getName().equals("logWarning"))
+            .count();
+    }
+
+    private Object lastWarningFinalArgument()
+    {
+        return mockingDetails(reporter).getInvocations().stream()
+            .filter(invocation -> invocation.getMethod().getName().equals("logWarning"))
+            .reduce((first, second) -> second)
+            .map(invocation -> invocation.getArguments()[invocation.getArguments().length - 1])
+            .orElse(null);
+    }
+
+    private class ProbeProvider extends ZfsThinProvider
+    {
+        private long delayMillis;
+        private long creationDelayMillis;
+        private long timeoutMillis = 4000;
+        private int failCreateTimes;
+        private int failCreateOnCall;
+        private boolean nullPath;
+        private boolean failDelete;
+        private boolean interruptDelete;
+        private int createCalls;
+        private int deleteCalls;
+        private ScheduledFuture<?> create;
+        private final AtomicInteger activeProbes = new AtomicInteger();
+        private final AtomicInteger peakActiveProbes = new AtomicInteger();
+
+        ProbeProvider(AbsStorageProviderInit initRef)
+        {
+            super(initRef);
+        }
+
+        @Override
+        protected long getWaitTimeoutAfterCreate(StorPool ignored)
+        {
+            return timeoutMillis;
+        }
+
+        @Override
+        public String createTmpProbeVlm(StorPool ignored) throws StorageException
+        {
+            peakActiveProbes.accumulateAndGet(activeProbes.incrementAndGet(), Math::max);
+            createCalls++;
+            if (creationDelayMillis > 0)
+            {
+                try
+                {
+                    Thread.sleep(creationDelayMillis);
+                }
+                catch (InterruptedException exc)
+                {
+                    throw new StorageException("Test probe creation interrupted", exc);
+                }
+            }
+            if (failCreateTimes > 0)
+            {
+                failCreateTimes--;
+                throw new StorageException("Probe creation failed");
+            }
+            if (failCreateOnCall == createCalls)
+            {
+                throw new StorageException("Probe creation failed");
+            }
+            if (nullPath)
+            {
+                return null;
+            }
+            if (delayMillis == 0)
+            {
+                try
+                {
+                    Files.createSymbolicLink(link, device);
+                }
+                catch (IOException exc)
+                {
+                    throw new StorageException("Test device creation failed", exc);
+                }
+            }
+            else if (delayMillis > 0)
+            {
+                create = executor.schedule(() -> Files.createSymbolicLink(link, device),
+                    delayMillis, TimeUnit.MILLISECONDS);
+            }
+            return link.toString();
+        }
+
+        @Override
+        public void deleteTmpProbeVlm(StorPool ignored) throws StorageException
+        {
+            deleteCalls++;
+            if (interruptDelete)
+            {
+                throw new StorageException("Probe cleanup interrupted", new InterruptedException());
+            }
+            if (failDelete)
+            {
+                throw new StorageException("Probe cleanup failed");
+            }
+            try
+            {
+                if (create != null && !create.cancel(false))
+                {
+                    create.get();
+                }
+                Files.deleteIfExists(link);
+                activeProbes.decrementAndGet();
+            }
+            catch (Exception exc)
+            {
+                throw new StorageException("Test device cleanup failed", exc);
+            }
+        }
+    }
+}

--- a/src/test/java/com/linbit/linstor/layer/storage/lvm/LvmProviderBlockDeviceInfoTest.java
+++ b/src/test/java/com/linbit/linstor/layer/storage/lvm/LvmProviderBlockDeviceInfoTest.java
@@ -24,10 +24,13 @@ import com.linbit.linstor.storage.StorageConstants;
 import com.linbit.linstor.storage.kinds.DeviceLayerKind;
 import com.linbit.linstor.storage.kinds.DeviceProviderKind;
 
+import java.nio.file.Path;
 import java.util.Collections;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +58,9 @@ public class LvmProviderBlockDeviceInfoTest extends GenericDbBase
 
     private TestExtCmd extCmd;
     private AbsStorageProviderInit providerInit;
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     /** Unique per test method since LvmUtils caches the lvm filter config statically per volume group set */
     private String vg;
@@ -130,7 +136,16 @@ public class LvmProviderBlockDeviceInfoTest extends GenericDbBase
     @Test
     public void thinPoolWithoutVolumesProbesWithTemporaryVolume() throws Exception
     {
-        LvmThinProvider lvmThinProvider = new LvmThinProvider(providerInit);
+        // TestExtCmd simulates lvcreate; use a real file for the resulting device path.
+        Path probeDevice = temporaryFolder.newFile("probe").toPath();
+        LvmThinProvider lvmThinProvider = new LvmThinProvider(providerInit)
+        {
+            @Override
+            public String getDevicePath(String storageNameRef, String lvIdRef)
+            {
+                return probeDevice.toString();
+            }
+        };
         StorPool storPool = createStorPool(DeviceProviderKind.LVM_THIN);
 
         expect(pvDisplayCommand(), "  " + PV_DEV + "\n");


### PR DESCRIPTION
Fixes #527.

A temporary ZFS volume may exist before udev publishes its device path. Wait for that path using the existing `WaitTimeoutAfterCreate` setting before reading block device information. Also use a temporary probe when the existing volume list contains only null or unusable device paths, while preserving the priority of usable volumes and read-only LVM probing.

Serialize the fixed-name probe lifecycle and retry transient failures up to three times. Always attempt cleanup, warn on exhausted attempts or cleanup failures, stop retrying after a cleanup failure, and preserve interruption during device waits, retry delays and cleanup.

Regression tests cover delayed and missing devices, unusable existing paths, transient failures, cleanup, interruption and concurrent probes. On unmodified master, 13 of the 16 regression tests fail.

Validated against master `c8c5ad1bbd02992d1e3fc8003ec0cedd2f7e21bb` on Linux amd64 with JDK 21: all 2316 tests pass, including all 16 new regression tests; `assemble` with Error Prone enabled and `checkstyleMain` both pass. Checkstyle reports existing warnings outside the changed code.
